### PR TITLE
fix: fix draggable bottom sheet makes overflow

### DIFF
--- a/src/app/(after-login)/course/[course-id]/page.tsx
+++ b/src/app/(after-login)/course/[course-id]/page.tsx
@@ -131,6 +131,7 @@ const CourseDetailPage = ({ params }: { params: { 'course-id': string } }) => {
                   options={{
                     disableDefaultUI: true,
                     clickableIcons: false,
+                    gestureHandling: 'greedy',
                   }}
                 >
                   <CourseDisplayOnMap

--- a/src/app/(after-login)/course/[course-id]/trekking/_components/result-page/result-page.tsx
+++ b/src/app/(after-login)/course/[course-id]/trekking/_components/result-page/result-page.tsx
@@ -37,6 +37,7 @@ const ResultPage = ({
   };
   const handleClickReview = () => {
     //TODO: 구현 필요
+    router.push('/my-info/complete-course-review');
   };
   return (
     <Layout hasTabBar={false} hasTopNav={true} back={true}>

--- a/src/app/(after-login)/course/[course-id]/trekking/page.tsx
+++ b/src/app/(after-login)/course/[course-id]/trekking/page.tsx
@@ -162,6 +162,7 @@ const TrakingPage = ({ params }: { params: { 'course-id': string } }) => {
               options={{
                 disableDefaultUI: true,
                 clickableIcons: false,
+                gestureHandling: 'greedy',
               }}
               onLoad={onLoad}
               onUnmount={onUnmount}
@@ -209,7 +210,8 @@ const TrakingPage = ({ params }: { params: { 'course-id': string } }) => {
         disableDrag={true}
         hasHeader={false}
         initialSnap={0}
-        snapPoints={[230]}
+        snapPoints={[225]}
+        contentHeight={true}
       >
         <Trekker
           courseName={course?.response.courseName!}
@@ -218,6 +220,11 @@ const TrakingPage = ({ params }: { params: { 'course-id': string } }) => {
           distance={totalDistance}
           handleClickStop={handleClickStop}
           handleClickPlayAndPause={handleClickPlayAndPause}
+        />
+        <div
+          style={{
+            height: '10px',
+          }}
         />
       </DraggableBottomSheet>
       <Dialog

--- a/src/app/(after-login)/course/_components/course-mapview/course-mapview.tsx
+++ b/src/app/(after-login)/course/_components/course-mapview/course-mapview.tsx
@@ -60,6 +60,7 @@ const CourseMapView = () => {
             options={{
               disableDefaultUI: true,
               clickableIcons: false,
+              gestureHandling: 'greedy',
             }}
             onClick={handleClickMap}
           >

--- a/src/components/common/draggable-bottomsheet/index.tsx
+++ b/src/components/common/draggable-bottomsheet/index.tsx
@@ -1,10 +1,11 @@
+import { useEffect } from 'react';
 import { Sheet } from 'react-modal-sheet';
 
 import classNames from 'classnames/bind';
 
 import styles from './index.module.scss';
 
-const baseSnapPoints = [-118, 0.4, 0];
+const baseSnapPoints = [-118, 0.35, 0];
 const baseInitialSnap = 1;
 
 interface DraggableBottomSheetProps {
@@ -13,6 +14,7 @@ interface DraggableBottomSheetProps {
   hasHeader?: boolean;
   snapPoints?: number[];
   initialSnap?: number;
+  contentHeight?: boolean;
   onClose: () => void;
   children: React.ReactNode;
 }
@@ -26,9 +28,21 @@ const DraggableBottomSheet = ({
   initialSnap = baseInitialSnap,
   disableDrag,
   hasHeader = true,
+  contentHeight = false,
   onClose,
   children,
 }: DraggableBottomSheetProps) => {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
   return (
     <Sheet
       isOpen={isOpen}
@@ -36,7 +50,7 @@ const DraggableBottomSheet = ({
       snapPoints={snapPoints}
       initialSnap={initialSnap}
       disableDrag={disableDrag}
-      detent='full-height'
+      detent={contentHeight ? 'content-height' : 'full-height'}
       className={cx(BLOCK)}
     >
       <Sheet.Container className={cx(`${BLOCK}__container`)}>


### PR DESCRIPTION
## Summary (요약)
실제 테스트환경에서 드래그가능한 바텀시트의 overflow로 인한 레이아웃 버그를 수정했습니다.
지도 동작을 수정했습니다
트래킹 결과 페이지에서의 라우팅동작을 추가했습니다.

## Changes (변경 사항)
1. 바텀시트 활성화 시, overflow:hidden 추가하여 overflow로 인한 레이아웃 버그를 수정했습니다.
2. 지도를 한손으로 드래그가능하도록 변경했습니다. 
3. 트래킹 결과 페이지에서 review 버튼 클릭 시, 완주코스목록으로 이동하도록 라우팅을 추가했습니다.

## Type of change (변경 유형)

<!-- PR의 변경 유형을 선택하세요. 중복 선택 가능합니다. -->

- [x] Bug fix (버그 수정)
- [ ] New feature (새로운 기능 추가)
- [ ] Style (스타일)
- [ ] Refactoring (리팩토링)
- [ ] Documentation (문서화)
- [ ] Tests (테스트 추가/수정)
- [ ] Other (기타)

## Related Issue (관련 이슈)

<!-- 이 PR과 관련된 이슈 번호를 링크하세요. -->

- Issue: # 

## Screenshots (스크린샷)

<!-- UI 변경 사항이 있으면 스크린샷을 첨부하세요. -->

| 변경 전 | 변경 후 |
|:--:|:--:|
| 이미지 1 | 이미지 2 |

## Checklist (체크리스트)

<!-- PR이 제출되기 전에 아래 사항을 확인하세요. -->

- [x] [팀 컨벤션](https://github.com/kakao-travel-mandi/mandi-frontend/wiki/Team-Convention)을 준수하였나요?
- [x] 빌드가 정상적으로 통과되었나요?
- [x] 리뷰어가 이해하기 쉽게 커밋 메시지를 작성했나요?

## Additional Context (추가 사항)

<!-- 이 PR에 대해 추가로 설명할 사항이 있으면 적어주세요. -->
