### PR TITLE
fix: fix bottoom sheet bug and layout component style

### DIFF
--- a/src/app/(after-login)/course/[course-id]/trekking/page.tsx
+++ b/src/app/(after-login)/course/[course-id]/trekking/page.tsx
@@ -133,6 +133,15 @@ const TrakingPage = ({ params }: { params: { 'course-id': string } }) => {
     }
   }, [courseStatus, CourseError, router]);
 
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
+
   if (showResult)
     return (
       <ResultPage

--- a/src/app/(after-login)/course/page.module.scss
+++ b/src/app/(after-login)/course/page.module.scss
@@ -1,6 +1,14 @@
 @use "@/styles/color.scss" as *;
 @use "@/styles/font.scss" as *;
 
+.container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 .list-container {
   position: relative;
   display: flex;

--- a/src/app/(after-login)/course/page.tsx
+++ b/src/app/(after-login)/course/page.tsx
@@ -28,36 +28,38 @@ const Course = () => {
 
   return (
     <Layout hasTopNav={false} hasTabBar={true}>
-      <div
-        className={cx(layout === 'list' ? 'list-searchbox' : 'map-searchbox')}
-        onClick={handleClickSearch}
-      >
-        <Input
-          placeholder='Course name, Location or Other.'
-          value=''
-          leftIcon={<IconSearch width={20} height={20} />}
-          rightIcon={<IconXCircle width={20} height={20} />}
-          className={cx(layout === 'map' && 'map-searchbox__input')}
-          style={{
-            pointerEvents: 'none',
-          }}
+      <div className={cx('container')}>
+        <div
+          className={cx(layout === 'list' ? 'list-searchbox' : 'map-searchbox')}
+          onClick={handleClickSearch}
+        >
+          <Input
+            placeholder='Course name, Location or Other.'
+            value=''
+            leftIcon={<IconSearch width={20} height={20} />}
+            rightIcon={<IconXCircle width={20} height={20} />}
+            className={cx(layout === 'map' && 'map-searchbox__input')}
+            style={{
+              pointerEvents: 'none',
+            }}
+          />
+        </div>
+        {layout === 'list' ? (
+          <div className={cx('list-container')}>
+            <Suspense>
+              <FilteredCourse />
+            </Suspense>
+          </div>
+        ) : (
+          layout === 'map' && <CourseMapView />
+        )}
+        <ViewSwitchButton
+          visible={!(selectedItem !== null && layout === 'map')}
+          layout={layout}
+          onClick={handleLayoutChange}
+          className={cx('layout-switch-button')}
         />
       </div>
-      {layout === 'list' ? (
-        <div className={cx('list-container')}>
-          <Suspense>
-            <FilteredCourse />
-          </Suspense>
-        </div>
-      ) : (
-        layout === 'map' && <CourseMapView />
-      )}
-      <ViewSwitchButton
-        visible={!(selectedItem !== null && layout === 'map')}
-        layout={layout}
-        onClick={handleLayoutChange}
-        className={cx('layout-switch-button')}
-      />
     </Layout>
   );
 };

--- a/src/app/(after-login)/course/search/page.module.scss
+++ b/src/app/(after-login)/course/search/page.module.scss
@@ -1,4 +1,5 @@
 .container {
+  width: 100%;
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/src/components/common/draggable-bottomsheet/index.tsx
+++ b/src/components/common/draggable-bottomsheet/index.tsx
@@ -32,17 +32,17 @@ const DraggableBottomSheet = ({
   onClose,
   children,
 }: DraggableBottomSheetProps) => {
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
-    }
+  // useEffect(() => {
+  //   if (isOpen) {
+  //     document.body.style.overflow = 'hidden';
+  //   } else {
+  //     document.body.style.overflow = 'unset';
+  //   }
 
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
-  }, [isOpen]);
+  //   return () => {
+  //     document.body.style.overflow = 'unset';
+  //   };
+  // }, [isOpen]);
   return (
     <Sheet
       isOpen={isOpen}

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -37,7 +37,12 @@ export const Layout = (props: LayoutProps) => {
 
   return (
     <main className={cx(BLOCK, getMainClass(hasTopNav, hasTabBar))}>
-      {hasTopNav && <TopNavBar {...getTopNavProps(props)} />}
+      {hasTopNav && (
+        <TopNavBar
+          {...getTopNavProps(props)}
+          topNavBarClassName={cx(`${BLOCK}__top-navbar`)}
+        />
+      )}
       <div
         className={cx(
           `${BLOCK}__content`,

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -3,19 +3,25 @@
 
 .layout {
   height: 100vh;
+  display: flex;
+  flex-direction: column;
+
+  &__top-navbar{
+    flex-shrink: 0;
+  }
 
   &__content {
    flex-grow: 1;
-   height: 100%;
-   overflow-y: auto; 
+  //  height: 100%;
+   overflow-y: scroll; 
    scrollbar-width: none;
+  //  flex-shrink: 0;
   }
 
   &__tabbar {
-    position: sticky;
-    bottom: 0;
-    z-index: 1000;
+    // position: sticky;
+    // bottom: 0;
+    z-index: 10;
   }
- 
 }
 


### PR DESCRIPTION
## Summary (요약)
모바일환경에서 발생하는 draggable bottom sheet 레이아웃 에러를 수정했습니다.
레이아웃 컴포넌트의 레이아웃을 수정하여 컨텐츠 영역에 스크롤이 생기는 버그를 수정했습니다.

## Changes (변경 사항)

1. 트레킹 페이지 로딩 시, overflow:hidden으로 처리하여 해당 페이지에서 렌더링되는 바텀시트로 인해 페이지가 overflow되는 것을 방지했습니다.
2. 레이아웃 컴포넌트의 컨텐츠 영역이 스크롤 되는 버그를 수정했습니다.

## Type of change (변경 유형)

<!-- PR의 변경 유형을 선택하세요. 중복 선택 가능합니다. -->

- [x] Bug fix (버그 수정)
- [ ] New feature (새로운 기능 추가)
- [ ] Style (스타일)
- [ ] Refactoring (리팩토링)
- [ ] Documentation (문서화)
- [ ] Tests (테스트 추가/수정)
- [ ] Other (기타)

## Checklist (체크리스트)

<!-- PR이 제출되기 전에 아래 사항을 확인하세요. -->

- [x] [팀 컨벤션](https://github.com/kakao-travel-mandi/mandi-frontend/wiki/Team-Convention)을 준수하였나요?
- [x] 빌드가 정상적으로 통과되었나요?
- [x] 리뷰어가 이해하기 쉽게 커밋 메시지를 작성했나요?

